### PR TITLE
Fix starred constructions randomly clearing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ docs/.vitepress/cache/**
 easel-original
 # Note: Changed on 2-14-25
 package-lock.json
+
+bun.lockb

--- a/src/stores/construction.ts
+++ b/src/stores/construction.ts
@@ -467,6 +467,8 @@ export const useConstructionStore = defineStore("construction", () => {
    *
    * @param targetArr array to fill with the publically visible constructions
    * @return nothing - the passed array is directly modified.
+   *
+   * TODO look into making sure this function executed as expected
    */
   async function parsePublicCollection(
     targetArr: Array<SphericalConstruction>
@@ -555,33 +557,32 @@ export const useConstructionStore = defineStore("construction", () => {
    *
    * @param fromArr array of firebase public construction IDs to parse
    */
-  async function parseStarredConstructions(fromArr: string[])
-  {
-      if (fromArr.length > 0 && allPublicConstructions.length > 0) {
-        console.debug("List of favorite items", fromArr);
-        const [star, unstar] = allPublicConstructions.partition(s => {
-          const isStar = fromArr.some(favId => favId === s.publicDocId);
-          return isStar;
+  async function parseStarredConstructions(fromArr: string[]) {
+    if (fromArr.length > 0 && allPublicConstructions.length > 0) {
+      console.debug("List of favorite items", fromArr);
+      const [star, unstar] = allPublicConstructions.partition(s => {
+        const isStar = fromArr.some(favId => favId === s.publicDocId);
+        return isStar;
+      });
+      starredConstructions.value = star;
+      publicConstructions.value = unstar;
+      starredParsed = true;
+      if (star.length !== fromArr.length) {
+        EventBus.fire("show-alert", {
+          type: "info",
+          key: "Some of your starred constructions are not available anymore"
         });
-        starredConstructions.value = star;
-        publicConstructions.value = unstar;
-        starredParsed = true;
-        if (star.length !== fromArr.length) {
-          EventBus.fire("show-alert", {
-            type: "info",
-            key: "Some of your starred constructions are not available anymore"
-          });
-          const cleanStarred = fromArr.filter(fav => {
-            const pos = allPublicConstructions.findIndex(
-              z => fav === z.publicDocId
-            );
-            return pos >= 0;
-          });
-          await updateStarredArrayInFirebase(cleanStarred);
-        }
-      } else {
-        publicConstructions.value = allPublicConstructions;
+        const cleanStarred = fromArr.filter(fav => {
+          const pos = allPublicConstructions.findIndex(
+            z => fav === z.publicDocId
+          );
+          return pos >= 0;
+        });
+        await updateStarredArrayInFirebase(cleanStarred);
       }
+    } else {
+      publicConstructions.value = allPublicConstructions;
+    }
   }
 
   async function initialize() {

--- a/src/stores/construction.ts
+++ b/src/stores/construction.ts
@@ -187,6 +187,7 @@ export const useConstructionStore = defineStore("construction", () => {
   const { firebaseUid, starredConstructionIDs, userEmail, includedTools } =
     storeToRefs(acctStore);
   let currentUID: string | undefined = undefined;
+  let starredParsed: boolean = false;
 
   // watch for changes in the firebase collection
   watchDebounced(
@@ -223,30 +224,7 @@ export const useConstructionStore = defineStore("construction", () => {
     () => starredConstructionIDs.value,
     async favorites => {
       console.debug("Starred watcher", favorites);
-      if (favorites.length > 0) {
-        console.debug("List of favorite items", favorites);
-        const [star, unstar] = allPublicConstructions.partition(s => {
-          const isStar = favorites.some(favId => favId === s.publicDocId);
-          return isStar;
-        });
-        starredConstructions.value = star;
-        publicConstructions.value = unstar;
-        if (star.length !== favorites.length) {
-          EventBus.fire("show-alert", {
-            type: "info",
-            key: "Some of your starred constructions are not available anymore"
-          });
-          const cleanStarred = favorites.filter(fav => {
-            const pos = allPublicConstructions.findIndex(
-              z => fav === z.publicDocId
-            );
-            return pos >= 0;
-          });
-          await updateStarredArrayInFirebase(cleanStarred);
-        }
-      } else {
-        publicConstructions.value = allPublicConstructions;
-      }
+      parseStarredConstructions(favorites);
     },
     { deep: true }
   );
@@ -572,6 +550,40 @@ export const useConstructionStore = defineStore("construction", () => {
     );
   }
 
+  /**
+   * parse the starred and unstarred constructions from the firebase collection into arrays
+   *
+   * @param fromArr array of firebase public construction IDs to parse
+   */
+  async function parseStarredConstructions(fromArr: string[])
+  {
+      if (fromArr.length > 0 && allPublicConstructions.length > 0) {
+        console.debug("List of favorite items", fromArr);
+        const [star, unstar] = allPublicConstructions.partition(s => {
+          const isStar = fromArr.some(favId => favId === s.publicDocId);
+          return isStar;
+        });
+        starredConstructions.value = star;
+        publicConstructions.value = unstar;
+        starredParsed = true;
+        if (star.length !== fromArr.length) {
+          EventBus.fire("show-alert", {
+            type: "info",
+            key: "Some of your starred constructions are not available anymore"
+          });
+          const cleanStarred = fromArr.filter(fav => {
+            const pos = allPublicConstructions.findIndex(
+              z => fav === z.publicDocId
+            );
+            return pos >= 0;
+          });
+          await updateStarredArrayInFirebase(cleanStarred);
+        }
+      } else {
+        publicConstructions.value = allPublicConstructions;
+      }
+  }
+
   async function initialize() {
     // This function is invoked from App.vue
     appDB = getFirestore();
@@ -580,8 +592,8 @@ export const useConstructionStore = defineStore("construction", () => {
 
     await parsePublicCollection(allPublicConstructions);
     sortConstructionArray(allPublicConstructions);
+    await parseStarredConstructions(starredConstructionIDs.value);
     publicConstructions.value = allPublicConstructions.slice(0);
-    // console.debug(`Public constructions ${publicConstructions.value.length}`);
   }
 
   /**
@@ -739,7 +751,7 @@ export const useConstructionStore = defineStore("construction", () => {
   async function updateStarredArrayInFirebase(
     arr: Array<string>
   ): Promise<void> {
-    if (firebaseUid.value) {
+    if (firebaseUid.value && starredParsed) {
       const userDocRef = doc(appDB, "users", firebaseUid.value);
       await updateDoc(userDocRef, {
         userStarredConstructions: arr


### PR DESCRIPTION
the starred constructions functionality now properly checks to see if the public constructions list has been downloaded and the starred constructions list is not empty. This prevents the starred constructions from clearing on load, but it does not always guarantee that the public list and starred constructions list do not intersect (I.E., constructions may appear in both lists)