### PR TITLE
Scrum 79 update parsing of starred constructions

### DIFF
--- a/src/stores/construction.ts
+++ b/src/stores/construction.ts
@@ -571,6 +571,8 @@ export const useConstructionStore = defineStore("construction", () => {
    *
    * @param targetArr array to fill with the publically visible constructions
    * @return nothing - the passed array is directly modified.
+   *
+   * TODO look into making sure this function executed as expected
    */
   async function parsePublicCollection(
     targetArr: Array<SphericalConstruction>

--- a/src/stores/construction.ts
+++ b/src/stores/construction.ts
@@ -670,7 +670,7 @@ export const useConstructionStore = defineStore("construction", () => {
     if (fromArr.length > 0 && publicParsed) {
       console.debug("List of favorite items", fromArr);
       /* parse fromArr into a combination of ID and path */
-      const stars: StarredConstruction[] = [];
+      const stars: Array<StarredConstruction> = [];
       fromArr.forEach(x => {
         const split = x.split("/", 2);
         stars.push({
@@ -681,16 +681,30 @@ export const useConstructionStore = defineStore("construction", () => {
 
       console.debug("parsed stars: " + JSON.stringify(stars));
 
-      const [star, unstar] = allPublicConstructions.partition(s => {
-        const isStar = fromArr.some(favId => favId === s.publicDocId);
-        return isStar;
+      /*
+       * build list of starred and unstarred constructions, setting the path of the starred constructions
+       * to that of the star item rather than the constructions's owned path.
+       */
+      var starred: Array<SphericalConstruction> = [];
+      var unstarred: Array<SphericalConstruction> = [];
+      allPublicConstructions.forEach(s => {
+        var isStarred: boolean = false;
+        for (let star of stars) {
+          if (star.id === s.publicDocId) {
+            s.path = star.path;
+            starred.push(s);
+            isStarred = true;
+            return;
+          }
+        }
+        unstarred.push(s);
       });
-      starredConstructions.value = star;
-      publicConstructions.value = unstar;
+      starredConstructions.value = starred;
+      publicConstructions.value = unstarred;
       /* TODO remove */
       return;
 
-      if (star.length !== fromArr.length) {
+      if (starred.length !== fromArr.length) {
         EventBus.fire("show-alert", {
           type: "info",
           key: "Some of your starred constructions are not available anymore"

--- a/src/stores/construction.ts
+++ b/src/stores/construction.ts
@@ -2,7 +2,8 @@ import {
   ConstructionInFirestore,
   SphericalConstruction,
   ConstructionScript,
-  PublicConstructionInFirestore
+  PublicConstructionInFirestore,
+  StarredConstruction
 } from "@/types";
 import { Command } from "@/commands/Command";
 import { defineStore } from "pinia";
@@ -668,12 +669,27 @@ export const useConstructionStore = defineStore("construction", () => {
   async function parseStarredConstructions(fromArr: string[]) {
     if (fromArr.length > 0 && publicParsed) {
       console.debug("List of favorite items", fromArr);
+      /* parse fromArr into a combination of ID and path */
+      const stars: StarredConstruction[] = [];
+      fromArr.forEach(x => {
+        const split = x.split("/", 2);
+        stars.push({
+          id: split[0],
+          path: split[1] ?? ""
+        } as StarredConstruction);
+      });
+
+      console.debug("parsed stars: " + JSON.stringify(stars));
+
       const [star, unstar] = allPublicConstructions.partition(s => {
         const isStar = fromArr.some(favId => favId === s.publicDocId);
         return isStar;
       });
       starredConstructions.value = star;
       publicConstructions.value = unstar;
+      /* TODO remove */
+      return;
+
       if (star.length !== fromArr.length) {
         EventBus.fire("show-alert", {
           type: "info",

--- a/src/stores/construction.ts
+++ b/src/stores/construction.ts
@@ -701,8 +701,6 @@ export const useConstructionStore = defineStore("construction", () => {
       });
       starredConstructions.value = starred;
       publicConstructions.value = unstarred;
-      /* TODO remove */
-      return;
 
       if (starred.length !== fromArr.length) {
         EventBus.fire("show-alert", {
@@ -960,11 +958,13 @@ export const useConstructionStore = defineStore("construction", () => {
       /*
         yes, we found the construction in the local store:
           1. increment its star count
-          2. remove it from the local store's list of public constructions,
-          3. add it to the local store's list of starred constructions
-          4. update the star count and user's starred list in firebase
+          2. set its path to an empty string
+          3. remove it from the local store's list of public constructions,
+          4. add it to the local store's list of starred constructions
+          5. update the star count and user's starred list in firebase
        */
       publicConstructions.value[pos].starCount++;
+      publicConstructions.value[pos].path = "";
       const inPublic = publicConstructions.value.splice(pos, 1);
       starredConstructions.value.push(...inPublic);
       starredConstructionIDs.value.push(...inPublic.map(z => z.publicDocId!));

--- a/src/stores/construction.ts
+++ b/src/stores/construction.ts
@@ -571,8 +571,6 @@ export const useConstructionStore = defineStore("construction", () => {
    *
    * @param targetArr array to fill with the publically visible constructions
    * @return nothing - the passed array is directly modified.
-   *
-   * TODO look into making sure this function executed as expected
    */
   async function parsePublicCollection(
     targetArr: Array<SphericalConstruction>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -698,6 +698,11 @@ export interface UserProfile {
   userStarredConstructions?: Array<string>;
 }
 
+export interface StarredConstruction {
+  id: string;
+  path: string;
+}
+
 export enum AngleMode {
   NONE,
   LINES,


### PR DESCRIPTION
Starred constructions were not previously parsed with their path; now they are! May require some further testing once we start changing and saving new paths, but parsing existing paths works. Note that overriding the path of the constructions should be fine since starred constructions are only modified by changing the user's starred construction list, and never by saving those constructions again. Since the user cannot star their own constructions, this will never overwrite an owned path.